### PR TITLE
Setting a default page zoom out

### DIFF
--- a/style.css
+++ b/style.css
@@ -6,6 +6,8 @@
 
 body {
     background-color: #390020;
+    zoom: 90%; /* https://developer.mozilla.org/en-US/docs/Web/CSS/zoom 
+    https://caniuse.com/css-zoom */
 }
 
 iframe{


### PR DESCRIPTION
Al posto di fare un allert per consigliare la pagina con lo zoom del 90%, mettilo di default per la pagina, ma bisogna adattarlo per Firefox che non supporta la proprietà zoom, ma solo transform.
**PAGLIACCIO**
![cat-funny-looking-camera-cat-smurf](https://github.com/FedericoSlongo/my_site/assets/78198419/5c402d5b-0068-411c-a8b3-68d163fdaab6)
